### PR TITLE
feat: HMVP-14 | Return all members of a team

### DIFF
--- a/services/hx-core/internal/postgresql/query/team.sql
+++ b/services/hx-core/internal/postgresql/query/team.sql
@@ -14,6 +14,21 @@ RETURNING id, created_at, updated_at;
 -- name: SelectTeamById :one
 SELECT * FROM teams WHERE id = @id;
 
+-- name: SelectTeamWithMembersById :one
+SELECT
+    t.*,
+    json_agg(json_build_object('id', m.id, 'first_name', m.first_name, 'email', m.email)) AS members
+FROM
+    teams t
+JOIN
+    teams_members tm ON t.id = tm.team_id
+JOIN
+    users m ON tm.user_id = m.id
+WHERE
+    t.id = @id
+GROUP BY
+    t.id, t.name, t.created_by, t.created_at;
+
 -- name: SelectTeamsByCreatorId :many
 SELECT * FROM teams WHERE created_by = @created_by;
 

--- a/services/hx-core/internal/rest/team.go
+++ b/services/hx-core/internal/rest/team.go
@@ -43,13 +43,18 @@ func (h *TeamHandler) Register(r *chi.Mux) {
 	})
 }
 
-// -
+type Member struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
 
 type Team struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	GameID    string `json:"game_id"`
-	CreatedBy string `json:"created_by"`
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	GameID    string   `json:"game_id"`
+	CreatedBy string   `json:"created_by"`
+	Members   []Member `json:"members"`
 }
 
 type CreateTeamRequest struct {
@@ -176,6 +181,16 @@ func (t *TeamHandler) find(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var members []Member
+
+	for _, member := range team.Members {
+		members = append(members, Member{
+			ID:    member.ID,
+			Email: member.Email,
+			Name:  member.FirstName,
+		})
+	}
+
 	renderResponse(w, r,
 
 		&FindTeamResponse{
@@ -184,6 +199,7 @@ func (t *TeamHandler) find(w http.ResponseWriter, r *http.Request) {
 				Name:      team.Name,
 				GameID:    team.GameID,
 				CreatedBy: team.CreatedBy,
+				Members:   members,
 			},
 		},
 		http.StatusOK)

--- a/services/hx-core/internal/services/interfaces.go
+++ b/services/hx-core/internal/services/interfaces.go
@@ -21,6 +21,7 @@ type TeamRepository interface {
 	Create(ctx context.Context, params *internal.TeamCreateParams) (internal.Team, error)
 	FindByName(ctx context.Context, params string) (internal.Team, error)
 	Find(ctx context.Context, id string) (*internal.Team, error)
+	FindWithMembers(ctx context.Context, id string) (*internal.Team, error)
 	Update(ctx context.Context, id string, params *internal.TeamUpdateParams) (*internal.Team, error)
 	List(ctx context.Context, params *internal.TeamSearchParams) (*[]internal.Team, error)
 	CreateTeamMember(ctx context.Context, memberId, teamId string) (*internal.TeamMember, error)

--- a/services/hx-core/internal/services/invite.go
+++ b/services/hx-core/internal/services/invite.go
@@ -74,15 +74,15 @@ func (i *Invite) Accept(ctx context.Context, inviteId, userId string) error {
 		return errors.WrapErrorf(err, errors.ErrorCodeNotFound, "member already belongs to the team")
 	}
 
-	if invite.Status != internal.InviteStatusTypeAccepted {
-		return errors.WrapErrorf(err, errors.ErrorCodeUnknown, "inviteRepository.AcceptInvite")
-	}
-
 	// accept invite
 	if invite, err = i.inviteRepository.Update(ctx, internal.UpdateInviteParams{
 		ID:     invite.ID,
 		Status: internal.InviteStatusTypeAccepted,
 	}); err != nil {
+		return errors.WrapErrorf(err, errors.ErrorCodeUnknown, "inviteRepository.AcceptInvite")
+	}
+
+	if invite.Status != internal.InviteStatusTypeAccepted {
 		return errors.WrapErrorf(err, errors.ErrorCodeUnknown, "inviteRepository.AcceptInvite")
 	}
 

--- a/services/hx-core/internal/services/team.go
+++ b/services/hx-core/internal/services/team.go
@@ -36,7 +36,7 @@ func (t *Team) Create(ctx context.Context, params internal.TeamCreateParams) (in
 }
 
 func (t *Team) Find(ctx context.Context, id string) (*internal.Team, error) {
-	team, err := t.teamRepository.Find(ctx, id)
+	team, err := t.teamRepository.FindWithMembers(ctx, id)
 
 	if err != nil {
 		return &internal.Team{}, errors.WrapErrorf(err, errors.ErrorCodeUnknown, "teamRepository.Find")

--- a/services/hx-core/internal/team.go
+++ b/services/hx-core/internal/team.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Team struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	GameID      string `json:"game_id"`
-	CreatedBy   string `json:"created_by"`
-	TeamMembers []User `json:"members"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameID    string `json:"game_id"`
+	CreatedBy string `json:"created_by"`
+	Members   []User `json:"members"`
 }
 
 type TeamMember struct {


### PR DESCRIPTION
Uma outra opção que encontrei para a `Query` seria:
```sql
SELECT
    t.*,
    (
        SELECT
            json_agg(json_build_object('id', m.id, 'first_name', m.first_name, 'email', m.email))
        FROM
            teams_members tm
        JOIN
            users m ON tm.user_id = m.id
        WHERE
            t.id = tm.team_id
    ) AS members
FROM
    teams t
WHERE
    t.id = @id;
```
Assim eliminamos um `JOIN` usando uma `Subquery`.